### PR TITLE
add multiple objects ABMs schema and an example of full version Pertussis model

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,5 +1,5 @@
 name = "StateCharts"
-uuid = "BFC335C0-D564-425B-98AA-D5C699C8B7AB"
+uuid = "bfc335c0-d564-425b-98aa-d5c699c8b7ab"
 license = "MIT"
 authors = ["AlgebraicJulia Developer <email@algebraicjulia.org>"]
 version = "0.0.1"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -1,7 +1,11 @@
 [deps]
 AlgebraicABMs = "5a5e3447-9604-46e6-8d91-cb86f5f51721"
 AlgebraicRewriting = "725a01d3-f174-5bbd-84e1-b9417bad95d9"
+CairoMakie = "13f3f980-e62b-5c42-98c6-ff1f3baf88f0"
+Distributions = "31c24e10-a181-5473-b8eb-7969acd0382f"
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 Fleck = "5bb9b785-358c-4fee-af0f-b94a146244a8"
+GLMakie = "e9467ef8-e4e7-5192-8a1a-b1aee30e663a"
 Literate = "98b081ad-f1c9-55d3-8b20-4c87d4299306"
+Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
 StateCharts = "bfc335c0-d564-425b-98aa-d5c699c8b7ab"

--- a/docs/literate/Interface_functions.jl
+++ b/docs/literate/Interface_functions.jl
@@ -1,0 +1,181 @@
+using StateCharts
+using AlgebraicABMs, AlgebraicRewriting, Catlab
+using Fleck
+using Random
+import AlgebraicRewriting.Incremental.IncrementalSum: IncSumHomSet
+
+
+############################################## the interface functions ####################################################
+## Functions in this section are all included in the file "StateChartsInterface.jl", but this file is not #################
+## usable yet .After the extension dependency of "StateCharts.jl" registered, just delete these functions #################
+## in this section.                                                                                       #################
+###########################################################################################################################
+const DST = :TimeOut # the transtition type for discrete hazard
+const CTT = :Rate # the transtition type for continueous hazard
+const RLT = :Pattern # the transtition type for user defined rewrite rule
+
+""" automatically generate the ABM model schema from the state chart. This schema contains one object, and the name of this object is given by the input 
+argument: obn::Symbol. And each unit state chart (with one entrance transition) contributes one attributes of the object "obn" in the schema
+
+"""
+
+homs_name(cod::Symbol,dom::Symbol)=Symbol(String(cod)*String(dom))
+
+vectorify(n::Vector) = collect(n)
+vectorify(n::Tuple) = length(n) == 1 ? [n] : collect(n)
+vectorify(n::SubArray) = collect(n)
+vectorify(n) = [n]
+
+
+# function return the ABM model Schema based on the input state charts
+# the schema's structure is:
+# 1. one object: usually is Person
+# 2. each unit state chart contributes to one attribute
+
+function StateChartABMSchema_SingleObject(ss::AbstractStateChart,obn::Symbol=:P)
+    attrsType = enames(ss) # the attributes' type is the name of each unit state chart
+    obns = repeat([obn], length(attrsType))
+    attrs = map((x,y)->homs_name(x,y),obns,attrsType) # define the name of the map from the object "obn" to each attribute type
+    attrsTuple = map((x,y,z)->(x,y,z),attrs,obns,attrsType)
+    schema = BasicSchema([obn], [], attrsType, attrsTuple)
+    schema
+end
+
+# function return ABM model schema based on the input state charts
+# the schema's structure is:
+# 1. Objects: total number of states in state charts + 1 (the coproduct of the objects of states), the name of the coproduct
+#             object is given by input argument "obn"
+# 2. Morphisms: each object of state has a morphism to the "1" -- the coproduct of states
+
+function StateChartABMSchema_MultipleObjects(ss::AbstractStateChart,obn::Symbol=:P)
+    # generate the list of objects
+    obs = vcat(snames(ss),[obn])
+    # generate the list of morphisms
+    morphisms_names = map((x,y)-> homs_name(x,y), snames(ss), repeat([obn],length(snames(ss))))
+    morphisms = map((x,y,z)->(x,y,z),morphisms_names,snames(ss),repeat([obn],length(snames(ss))))
+    # create the schema
+    schema = BasicSchema(obs, morphisms)
+    # return the cset generated
+    schema       
+end
+
+function StateChartCset_SingleObject(ss::AbstractStateChart,obn::Symbol=:P)
+    attrsType = enames(ss)
+    schema = StateChartABMSchema_SingleObject(ss,obn)
+    tp_asgn = Dict(zip(attrsType,repeat([Symbol], length(attrsType))))
+    acset = AnonACSet(schema;type_assignment=tp_asgn)
+    acset
+end
+
+StateChartCset_MultipleObjects(ss::AbstractStateChart,obn::Symbol=:P) = AnonACSet(StateChartABMSchema_MultipleObjects(ss,obn))        
+
+# simulate a single transition, e.g., :I->:E
+function make_rule_SingleObject(ss::AbstractStateChart, l, r, i=[]; obn::Symbol=:P)
+    l = vectorify(l)
+    i = vectorify(i)
+    r = vectorify(r)
+    Lᵢ,Iᵢ,Rᵢ = [StateChartCset_SingleObject(ss,obn) for _ in 1:3]
+    # return the attribute names 
+    ## TODO: need to make "attrn" support multiple unit state chart, this needs to extend the 
+    ## schema of the state charts
+    attrn = attrs(acset_schema(Lᵢ);just_names=true)[1]
+    attrt = attrtypes(acset_schema(Lᵢ))[1]
+    add_parts!(Lᵢ,obn,length(l);attrn=>l)
+    add_part!(Iᵢ,obn;attrn=>AttrVar(add_part!(Iᵢ,attrt)))
+    add_parts!(Rᵢ,obn,length(r);attrn=>r)
+    Rule(homomorphism(Iᵢ,Lᵢ),homomorphism(Iᵢ,Rᵢ)) 
+end
+
+function make_infectious_rule_SingleObject(ss::AbstractStateChart,l,r,i,obn::Symbol=:P)
+    l = vectorify(l)
+    i = vectorify(i)
+    r = vectorify(r)
+    Lᵢ,Iᵢ,Rᵢ = [StateChartCset_SingleObject(ss,obn) for _ in 1:3]
+    # return the attribute names 
+    ## TODO: need to make "attrn" support multiple unit state chart, this needs to extend the 
+    ## schema of the state charts
+    attrn = attrs(acset_schema(Lᵢ);just_names=true)[1]
+    add_parts!(Lᵢ,obn,2;attrn=>l)
+    ic = findall(in(l), i)
+    @assert length(ic)==1 "There should only be 1 infective individual in the infectious rule!"
+    add_part!(Iᵢ,obn;attrn=>i[ic][1])
+    attrt = attrtypes(acset_schema(Lᵢ))[1]
+    add_part!(Iᵢ,obn;attrn=>AttrVar(add_part!(Iᵢ,attrt)))
+    add_parts!(Rᵢ,obn,2;attrn=>r)
+    Rule(homomorphism(Iᵢ,Lᵢ),homomorphism(Iᵢ,Rᵢ))
+end
+
+# l, include the objects of l, e.g., l=[:S,:I]
+# i, include the objects of i, e.g., i=[:S]
+# r, include the objects of r, e.g., r=[:I,:I]
+function make_rule_MultipleObjects(ss::AbstractStateChart, l, r, i=[]; obn::Symbol=:P)
+    l = vectorify(l)
+    i = vectorify(i)
+    r = vectorify(r)
+    Lᵢ,Iᵢ,Rᵢ = LIR = [StateChartCset_MultipleObjects(ss,obn) for _ in 1:3]
+    # add the object obn to L, I and R
+    map(x->add_part!(x,obn),LIR)
+
+    # add the (state) objects to L, I and R
+    map(x->add_part!(Lᵢ, x; homs_name(x,obn)=>1),l)
+    map(x->add_part!(Iᵢ, x; homs_name(x,obn)=>1),i)
+    map(x->add_part!(Rᵢ, x; homs_name(x,obn)=>1),r)
+
+    Rule(homomorphism(Iᵢ,Lᵢ),homomorphism(Iᵢ,Rᵢ)) 
+end
+
+function make_infectious_rule_MultipleObjects(ss::AbstractStateChart, l, r, i; obn::Symbol=:P) 
+    make_rule_MultipleObjects(ss, l, r, i, obn=obn)
+end
+
+# currently, suppose we only have one unit state chart
+# TODO: make it support multiple unit state charts
+# generate the rewrite rule
+# t is the index of a transition
+# transitions_rules is an array with pair of (timer, rule) as its elements
+function get_rule(ss::AbstractStateChart,t,transitions_rules;is_schema_singObject::Bool=true,obn::Symbol=:P)
+    tt = ttype(ss,t)
+    if tt == RLT
+        tidx=Int(texpr(ss,t))
+        return transitions_rules[tidx][2]
+    elseif tt in [DST, CTT]
+        # return the attribute names 
+        ## TODO: need to make "attrn" and "attrt" support multiple unit state chart, this needs to extend the 
+        ## schema of the state charts
+        l = sname(ss,tsource(ss,t))
+        r = sname(ss,ttarget(ss,t))
+        return is_schema_singObject ? make_rule_SingleObject(ss,l,r,obn=obn) : make_rule_MultipleObjects(ss,l,r,obn=obn)
+    else
+        tn = tname(ss,t)
+        throw("transition:$tn does not have valid transition type!")
+    end
+end
+
+function get_timer(ss::AbstractStateChart, transitions_rules,t;obn::Symbol=:P)
+    tt=ttype(ss,t)
+    if tt == DST
+        timeout = texpr(ss,t)
+        timer = DiscreteHazard(timeout)
+    elseif tt == CTT
+        r = texpr(ss,t)
+        timer = ContinuousHazard(1/r)
+    elseif tt == RLT
+        tidx=Int(texpr(ss,t))
+        timer = transitions_rules[tidx][1]
+    else
+        tn = tname(ss,t)
+        throw("transition:$tn does not have valid transition type!")
+    end
+    timer
+end
+
+function make_ABM(ss::AbstractStateChart, transitions_rules;is_schema_singObject::Bool=true) 
+    return ABM(map(parts(ss, :T)) do t
+        tn = tname(ss, t)
+        ABMRule(tn, get_rule(ss, t,transitions_rules,is_schema_singObject=is_schema_singObject), get_timer(ss,transitions_rules,t))
+    end, [])
+end
+
+#############################################################################################
+######################### end of the dependency function part ###############################
+

--- a/docs/literate/pertussis_Hethcote_model_with_run_AlgebraicABMs.jl
+++ b/docs/literate/pertussis_Hethcote_model_with_run_AlgebraicABMs.jl
@@ -1,114 +1,18 @@
-using StateCharts
-using AlgebraicABMs, AlgebraicRewriting, Catlab
-using Fleck
-using Random
-import AlgebraicRewriting.Incremental.IncrementalSum: IncSumHomSet
+include("Interface_functions.jl")
+
+using Makie, CairoMakie
 ENV["JULIA_DEBUG"] = "AlgebraicABMs"; 
-
-############################################## the interface functions ####################################################
-## Functions in this section are all included in the file "StateChartsInterface.jl", but this file is not #################
-## usable yet .After the extension dependency of "StateCharts.jl" registered, just delete these functions #################
-## in this section.                                                                                       #################
-###########################################################################################################################
-const DST = :TimeOut # the transtition type for discrete hazard
-const CTT = :Rate # the transtition type for continueous hazard
-const RLT = :Pattern # the transtition type for user defined rewrite rule
-
-""" automatically generate the ABM model schema from the state chart. This schema contains one object, and the name of this object is given by the input 
-argument: obn::Symbol. And each unit state chart (with one entrance transition) contributes one attributes of the object "obn" in the schema
-
-"""
-
-function StateChartCset_SingleObject(ss::AbstractStateChart,obn::Symbol=:P)
-    attrsType = enames(ss) # the attributes' type is the name of each unit state chart
-    obns = repeat([obn], length(attrsType))
-    attrs = map((x,y)->Symbol(String(x)*String(y)),obns,attrsType) # define the name of the map from the object "obn" to each attribute type
-    attrsTuple = map((x,y,z)->(x,y,z),attrs,obns,attrsType)
-    schema = BasicSchema([obn], [], attrsType, attrsTuple)
-    tp_asgn = Dict(zip(attrsType,repeat([Symbol], length(attrsType))))
-    acset = AnonACSet(schema;type_assignment=tp_asgn)
-    acset
-end
-
-function StateChartCset_MultipleObject(ss::AbstractStateChart)   
-end
-
-function make_infectious_rule(ss::AbstractStateChart;make_acset::Function=StateChartCset_SingleObject,r::Symbol=:I,obn::Symbol=:P)
-    Lᵢ,Iᵢ,Rᵢ = [make_acset(ss,obn) for _ in 1:3]
-    # return the attribute names 
-    ## TODO: need to make "attrn" support multiple unit state chart, this needs to extend the 
-    ## schema of the state charts
-    attrn = attrs(acset_schema(Lᵢ);just_names=true)[1]
-    add_parts!(Lᵢ,obn,2;attrn=>[:S,:I])
-    add_part!(Iᵢ,obn;attrn=>:I)
-    add_parts!(Rᵢ,obn,2;attrn=>[r,:I])
-    Rule(homomorphism(Iᵢ,Lᵢ),homomorphism(Iᵢ,Rᵢ)) 
-end
-
-# currently, suppose we only have one unit state chart
-# TODO: make it support multiple unit state charts
-# generate the rewrite rule
-# t is the index of a transition
-# transitions_rules is an array with pair of (timer, rule) as its elements
-function get_rule(ss::AbstractStateChart,t,transitions_rules,obn::Symbol=:P)
-    tt = ttype(ss,t)
-    if tt == RLT
-        tidx=Int(texpr(ss,t))
-        rule = transitions_rules[tidx][2]
-    elseif tt in [DST, CTT]
-        L,I,R = LIR = [StateChartCset_SingleObject(ss,obn) for _ in 1:3]
-        # return the attribute names 
-        ## TODO: need to make "attrn" and "attrt" support multiple unit state chart, this needs to extend the 
-        ## schema of the state charts
-        attrn = attrs(acset_schema(L);just_names=true)[1]
-        attrt = attrtypes(acset_schema(L))[1]
-        add_part!(L,obn;attrn=>sname(ss,tsource(ss,t)))
-        add_part!(I,obn;attrn=>AttrVar(add_part!(I,attrt)))
-        add_part!(R,obn;attrn=>sname(ss,ttarget(ss,t)))
-        rule = Rule(homomorphism(I,L),homomorphism(I,R))  
-    else
-        tn = tname(ss,t)
-        throw("transition:$tn does not have valid transition type!")
-    end
-end
-
-function get_timer(ss::AbstractStateChart,t,obn::Symbol=:P)
-    tt=ttype(ss,t)
-    if tt == DST
-        timeout = texpr(ss,t)
-        timer = DiscreteHazard(timeout)
-    elseif tt == CTT
-        r = texpr(ss,t)
-        timer = ContinuousHazard(1/r)
-    elseif tt == RLT
-        tidx=Int(texpr(ss,t))
-        timer = transitions_rules[tidx][1]
-    else
-        tn = tname(ss,t)
-        throw("transition:$tn does not have valid transition type!")
-    end
-    timer
-end
-
-function make_ABM(ss::AbstractStateChart) 
-    return ABM(map(parts(ss, :T)) do t
-        tn = tname(ss, t)
-        ABMRule(tn, get_rule(ss, t,transitions_rules), get_timer(ss,t))
-    end, [])
-end
-
-#############################################################################################
-######################### end of the dependency function part ###############################
-
 
 ### example code starts here ###
 
-totalPopulation=10.0
-β = 0.001
+totalPopulation=100.0
+β = 0.1
+#p_becomingInfective = 5.0
+p_becomingInfective = TriangularDist(2.0, 10.0, 5.0)
 
 # create the pertussis state chart
 pertussis = StateChartF((:S,:E,:I,:R₄,:V₄), # states
-(:newExposure=>(:S=>:E,:Pattern=>1),:becomingInfective=>(:E=>:I,:TimeOut=>5.0),:recovery=>(:I=>:R₄,:Rate=>1.0/21.0),:vaccinated=>(:S=>:V₄,:Rate=>0.01)), #non-start transitions
+(:newExposure=>(:S=>:E,:Pattern=>1),:becomingInfective=>(:E=>:I,:TimeOut=>p_becomingInfective),:recovery=>(:I=>:R₄,:Rate=>1.0/21.0),:vaccinated=>(:S=>:V₄,:Rate=>0.01)), #non-start transitions
 (), # alternatives for non-start transitions
 (:PertussisStateChart=>:S), # start transitions
 (:PertussisStateChart=>((:initialInfective,1.0/totalPopulation)=>:I)) # alternatives for start transitions
@@ -116,14 +20,31 @@ pertussis = StateChartF((:S,:E,:I,:R₄,:V₄), # states
 
 StateCharts.Graph(pertussis)
 
+########### use ABM model schema of one object P #####################
+########### the states of state charts are attributes ################
+
 # define the new_infectious rule
-transitions_rules=[(ContinuousHazard(1/β),make_infectious_rule(pertussis,r=:E))]
+transitions_rules_SingleObject=[(ContinuousHazard(1/β),make_infectious_rule_SingleObject(pertussis,r=:E))]
 
-# Initial state
-init = StateChartCset_SingleObject(pertussis)
-add_parts!(init,:P,Int(totalPopulation-1),PPertussisStateChart=:S)
-add_part!(init,:P,PPertussisStateChart=:I)
+# Initial state for schema of single object
+init_SingleObject = StateChartCset_SingleObject(pertussis)
+add_parts!(init_SingleObject,:P,Int(totalPopulation-1),PPertussisStateChart=:S)
+add_part!(init_SingleObject,:P,PPertussisStateChart=:I)
 
-res = run!(make_ABM(pertussis), init; maxtime=20);
+res = run!(make_ABM(pertussis,transitions_rules_SingleObject,is_schema_singObject=true), init_SingleObject; maxtime=20);
 
-#Makie.plot(res; Dict(o=>X->nparts(X,o) for o in [:S,:I])...)
+########### use ABM model schema of multiple objects#####################
+########### each state of state charts is an object, they are all #######
+########### map to a collection object, e.g., total population ##########
+
+transitions_rules_MultipleObjects=[(ContinuousHazard(1/β),make_infectious_rule_MultipleObjects(pertussis,r=:E))]
+
+# Initial state for schema of multiple objects
+init_MultipleObjects = StateChartCset_MultipleObjects(pertussis)
+add_parts!(init_MultipleObjects,:P,Int(totalPopulation))
+add_parts!(init_MultipleObjects,:S,Int(totalPopulation-1),SP=1)
+add_part!(init_MultipleObjects,:I,IP=1)
+
+res = run!(make_ABM(pertussis,transitions_rules_MultipleObjects,is_schema_singObject=false), init_MultipleObjects; maxtime=1000);
+
+Makie.plot(res; Dict(o=>X->nparts(X,o) for o in [:S,:E,:I,:R₄,:V₄])...)

--- a/docs/literate/pertussis_full_model.jl
+++ b/docs/literate/pertussis_full_model.jl
@@ -1,0 +1,183 @@
+include("Interface_functions.jl")
+
+using Makie, CairoMakie
+import Base: *
+ENV["JULIA_DEBUG"] = "AlgebraicABMs"; 
+
+*(x::Symbol, y::Symbol) = Symbol(String(x)*String(y))
+
+# define the parameter values
+totalPopulation=100.0
+c = 0.1411 * 10 # calculated by the average value among the 32 age groups in Hethocote model
+
+# the transmission probability seems very high to me. So I temporarily times 0.2 of it. 
+# TODO: need to talk to Dr.Osgood of the values of it
+β = [0.8,0.4,0.2] * 0.2 # 0.8 for full Infectives I
+                  # 0.4 for mild Infectives Im
+                  # 0.2 for weak Infectives Iw
+p_vaccinationRate = 0.76 / 365.0 # per day, auxiliary value
+# The values of "p_incubationPeriodInDay_Im" and "p_incubationPeriodInDay_Iw" refers to the parameter settings in the published paper
+# (in Table 1: https://peerj.com/articles/2337/#table-1), instead of the specfic Anylogic model.
+p_incubationPeriodInDay_I = 10
+p_incubationPeriodInDay_Im = 14
+p_incubationPeriodInDay_Iw = 21
+p_gam = 1 / 21.0
+p_alp = 1 / (5 * 365.0) # wanning rate of R
+p_tau = 1 / (2 * 365.0) # wanning rate of V
+p_eps = 1 / (100 * 365.0) # wanning rate from R1 or V1 to S
+
+Incubations = [:Incubation_I, :Incubation_Im, :Incubation_Iw]
+Infectives = [:Infective_I, :Infective_Im, :Infective_Iw]
+IContacts_idx = Dict(:StoI=>1:3,
+                        :V1toI=>4:6,
+                        :R1toIm=>7:9,
+                        :V2toIm=>10:12,
+                        :R2toIw=>13:15,
+                        :R3toR4=>16:18,
+                        :V3toR4=>19:21)
+
+# define the states
+states = [:Susceptible,
+# 3 incubation states, with decreasing levels of coming virulence
+:Incubation_I,
+:Incubation_Im, 
+:Incubation_Iw,
+# infective states, with decreasing levels of virulence
+:Infective_I,
+:Infective_Im, 
+:Infective_Iw,
+# recovered states, with INCREASING levels of protection
+:Recovered_1,
+:Recovered_2,
+:Recovered_3,
+:Recovered_4,
+# recovered states, with INCREASING levels of protection
+:Vaccinated_1,
+:Vaccinated_2,
+:Vaccinated_3,
+:Vaccinated_4]
+
+# create the pertussis state chart
+pertussisStatechart = StateChartF(states, # states
+    (   
+        # we deal here with transitions from Susceptible.
+
+        # first, we deal with the single vaccination transition for a susceptible person
+        :t_transition42_vaccinationFromSusceptible=>(:Susceptible=>:Vaccinated_1,:Rate=>p_vaccinationRate),
+
+        # next, we deal successively with the infection transitions to incubation states 
+        # for each of full-strength, mild and weak infections in turn
+        map((x,y)->:t_S_I_newExposure_FullStrength_ * x =>(:Susceptible=>:Incubation_I,:Pattern=>y), Infectives, IContacts_idx[:StoI])...,
+
+        #:t_V1_I_Vaccinated_1_I_newExposure_FullStrength=>(:Vaccinated_1=>:Incubation_I,:Pattern=>1),
+        map((x,y)->:t_V1_I_Vaccinated_1_I_newExposure_FullStrength_ * x =>(:Vaccinated_1=>:Incubation_I,:Pattern=>y), Infectives, IContacts_idx[:V1toI])...,
+
+        #:t_R1_mI_newExposure_mild=>(:Recovered_1=>:Incubation_Im,:Pattern=>1),
+        map((x,y)->:t_R1_mI_newExposure_mild_ * x =>(:Recovered_1=>:Incubation_Im,:Pattern=>y), Infectives, IContacts_idx[:R1toIm])...,
+
+        #:t_V2_mI_Vaccinated_2_I_newExposure_mild=>(:Vaccinated_2=>:Incubation_Im,:Pattern=>1),
+        map((x,y)->:t_V2_mI_Vaccinated_2_I_newExposure_mild_ * x =>(:Vaccinated_2=>:Incubation_Im,:Pattern=>y), Infectives, IContacts_idx[:V2toIm])...,
+        
+        #:t_R2_wI_newExposure_weak=>(:Recovered_2=>:Incubation_Iw,:Pattern=>1),
+        map((x,y)->:t_R2_wI_newExposure_weak_ * x =>(:Recovered_2=>:Incubation_Iw,:Pattern=>y), Infectives, IContacts_idx[:R2toIw])...,
+        
+        # next, we deal successively with the post-incubation transitions to infectivity for each of 
+        # full-strength, mild and weak infections in turn
+        :t_transition41_becomingInfective_FullStrength=>(:Incubation_I=>:Infective_I,:TimeOut=>p_incubationPeriodInDay_I),
+        
+        :becomingInfective_mild=>(:Incubation_Im=>:Infective_Im,:TimeOut=>p_incubationPeriodInDay_Im),
+        
+        :becomingInfective_weak=>(:Incubation_Iw=>:Infective_Iw,:TimeOut=>p_incubationPeriodInDay_Im),
+
+        # now we deal with infection transitions that are too weak to 
+        # trigger incubation & infectivity.  These occur from Recovered_2 and
+        # and Vaccinated_3; note that lower levels of both natural & vaccine-induced
+        # immunity lead to infectivity, and pathogen exposure induces no change at higher 
+        # levels of immunity.
+        # First, boosting of immunity from natural recovery
+        #:t_R3_R4_exposureBoostingRecovery_3=>(:Recovered_3=>:Recovered_4,:Pattern=>1),
+        map((x,y)->:t_R3_R4_exposureBoostingRecovery_3_ * x =>(:Recovered_3=>:Recovered_4,:Pattern=>y), Infectives, IContacts_idx[:R3toR4])...,
+
+        # NB: The model posits that exposure to pathogen in Vaccinated_3 indeed 
+        # confers immunity comparable to from natural infection (i.e., to Recovery_4)
+        #:t_V3_R4_exposureBoostingWanedVaccinated_3=>(:Vaccinated_3=>:Recovered_4,:Pattern=>1),
+        map((x,y)->:t_V3_R4_exposureBoostingWanedVaccinated_3_ * x =>(:Vaccinated_3=>:Recovered_4,:Pattern=>y), Infectives, IContacts_idx[:V3toR4])...,
+
+        # having dealt with infection transitions, 
+        # we next deal with recovery (departure from states of infectivity) for
+        # each virulence level; all are governed by hazard rate gam and go to Recovered_4 
+        :t_gam_I_recoveryFromFullStrengthInfection=>(:Infective_I=>:Recovered_4,:Rate=>p_gam),
+       
+        :t_gam_ml_recoveryFromMildInfection=>(:Infective_Im=>:Recovered_4,:Rate=>p_gam),
+
+        :t_gam_wI_recoveryFromWeakInfection=>(:Infective_Iw=>:Recovered_4,:Rate=>p_gam),
+
+
+        # transitions involving waning of immunity from recovery states  
+        :t_alp_R4_waningImmunityFromRecovered_4=>(:Recovered_4=>:Recovered_3,:Rate=>p_alp),
+
+        :t_alp_R3_waningImmunityFromRecovered_3=>(:Recovered_3=>:Recovered_2,:Rate=>p_alp),
+        
+        :t_alp_R2_waningImmunityFromRecovered_2=>(:Recovered_2=>:Recovered_1,:Rate=>p_alp),
+
+        :t_alp_R1_waningImmunityFromRecovered_1=>(:Recovered_1=>:Susceptible,:Rate=>p_eps),
+
+
+        # now we deal with the transitions involving receipt of vaccines whilst in a recovered state
+        # NB: There is no opportunity to boost immunity through vaccination (or natural exposure) 
+        # in the highest state of natural induced immunity (Recovered_4)
+        :t_transition6_vaccinationFromRecovered_1=>(:Recovered_1=>:Recovered_2,:Rate=>p_vaccinationRate),
+
+        :t_transition8_vaccinationFromRecovered_2=>(:Recovered_2=>:Recovered_3,:Rate=>p_vaccinationRate),
+
+        :t_R3_R4_vaccinationFromRecovered_3=>(:Recovered_3=>:Recovered_4,:Rate=>p_vaccinationRate),
+        
+
+        # transitions involving waning of immunity from vaccinated states  
+        :t_tau_V4_waningImmunityFromVaccinated_4=>(:Vaccinated_4=>:Vaccinated_3,:Rate=>p_tau),
+
+        :t_tau_V3_waningImmunityFromVaccinated_3=>(:Vaccinated_3=>:Vaccinated_2,:Rate=>p_tau),
+
+        :t_tau_V2_waningImmunityFromVaccinated_2=>(:Vaccinated_2=>:Vaccinated_1,:Rate=>p_tau),
+
+        :t_eps_S_waningImmunityFromVaccinated_1=>(:Vaccinated_1=>:Susceptible,:Rate=>p_eps),
+        
+        
+        # finally, we have transitions involving receipt of vaccines whilst in a vaccinated state
+        # NB: There is no opportunity to boost immunity through vaccination (or natural exposure) 
+        # in the highest state of vaccine-induced immunity (Vaccinated_4)
+        :t_transition10_vaccinationFromVaccinated_1=>(:Vaccinated_1=>:Vaccinated_2,:Rate=>p_vaccinationRate),
+
+        :t_transition11_vaccinationFromVaccinated_2=>(:Vaccinated_2=>:Vaccinated_3,:TimeOut=>p_vaccinationRate),
+
+        :t_transition12_vaccinationFromVaccinated_3=>(:Vaccinated_3=>:Vaccinated_4,:TimeOut=>p_vaccinationRate),    
+    ), #non-start transitions
+(), # alternatives for non-start transitions
+(:PertussisStateChart=>:Susceptible), # start transitions
+(:PertussisStateChart=>((:initialInfective,1.0/totalPopulation)=>:Infective_I)) # alternatives for start transitions
+)
+
+StateCharts.Graph(pertussisStatechart)
+
+# define the rewrite rules for contacts of Infectives
+f_infective_collect(S::Symbol,I::Symbol) = map(x->[[S,x],[I,x],[x]],Infectives)
+transitions_rules = [map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Susceptible,:Incubation_I))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Vaccinated_1,:Incubation_I))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Recovered_1,:Incubation_Im))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Vaccinated_2,:Incubation_Im))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Recovered_2,:Incubation_Iw))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Recovered_3,:Recovered_4))...,
+                     map((x,y)->ContinuousHazard(1/(c*x))=>make_infectious_rule_MultipleObjects(pertussisStatechart,y...),β,f_infective_collect(:Vaccinated_3,:Recovered_4))...
+];
+
+# define the initial state
+init = StateChartCset_MultipleObjects(pertussisStatechart)
+add_parts!(init,:P,Int(totalPopulation))
+add_parts!(init,:Susceptible,Int(totalPopulation-1),SusceptibleP=1)
+add_part!(init,:Infective_I,Infective_IP=1)
+
+# run the ABM model
+res = run!(make_ABM(pertussisStatechart,transitions_rules,is_schema_singObject=false), init; maxtime=20);
+
+# plot out the results of each state
+Makie.plot(res; Dict(o=>X->nparts(X,o) for o in states)...)

--- a/src/StateCharts.jl
+++ b/src/StateCharts.jl
@@ -55,6 +55,7 @@ end
 
 @abstract_acset_type AbstractStateChart
 @acset_type StateChartUntype(TheoryStateChart) <: AbstractStateChart
+#const StateChart = StateChartUntype{Symbol,Union{Float16,Sampleable},Symbol}
 const StateChart = StateChartUntype{Symbol,Float16,Symbol}
 
 # define functions of adding components of state charts


### PR DESCRIPTION
1. The multiple objects schema is:
each state in the state chart is an object in the schema, and they all have a morphism to the whole population object.

2. Also add an example of the full version of Pertussis Hethcote model.
